### PR TITLE
Improve builds with Webpack 2 integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,11 +35,7 @@
   },
   "homepage": "https://github.com/ericclemmons/terse-js#readme",
   "devDependencies": {
-    "babel-cli": "6.7.5",
-    "babel-register": "6.7.2",
-    "expect": "1.16.0",
     "github-semantic-version": "4.0.13",
-    "mocha": "2.4.5",
     "rimraf": "2.5.2"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "babel src -d dist",
-    "prepublish": "npm run build",
+    "prerelease": "npm run build",
     "release": "github-semantic-version",
     "pretest": "npm run build",
     "test": "mocha",

--- a/package.json
+++ b/package.json
@@ -39,19 +39,6 @@
     "rimraf": "2.5.2"
   },
   "dependencies": {
-    "babel-core": "6.7.6",
-    "babel-loader": "6.2.4",
-    "babel-preset-es2015": "6.6.0",
-    "babel-preset-react": "6.5.0",
-    "babel-preset-stage-1": "6.5.0",
-    "eslint": "2.7.0",
-    "eslint-loader": "1.3.0",
-    "express": "4.13.4",
-    "express-hot-middleware": "1.0.2",
-    "source-map-support": "0.4.0",
-    "start-server-webpack-plugin": "2.0.0",
-    "webpack": "1.12.15",
-    "webpack-dev-middleware": "1.6.1",
-    "webpack-hot-middleware": "2.10.0"
+    "webpack": "2.1.0-beta.7"
   }
 }


### PR DESCRIPTION
After testing out Webpack 2 (beta) with tree shaking and minification I am seeing good improvements on file size when building apps in react. Typical none tree shaking just grabs the code you require and puts it into your code base. I noticed a fresh application with only a couple react components using tree shaking was at around 40kb in size after gzipped.

Besides the tree shaking I believe it would be good to start fresh with Webpack 2. It's usually new projects that people are needing terse webpack anyway.